### PR TITLE
feat: Add skipReaderAccounts config parameter

### DIFF
--- a/src/SnowflakeQueryHistory/Component.php
+++ b/src/SnowflakeQueryHistory/Component.php
@@ -130,63 +130,68 @@ class Component extends BaseComponent
         $this->writeManifest($this->getDataDir() . '/out/tables/queries.csv.manifest');
 
         // READER_ACCOUNT_USAGE.QUERY_HISTORY
-        if (isset($stateDecoded['readerAccountLatestEndTime'])) {
-            $readerAccountStartTime = $stateDecoded['readerAccountLatestEndTime'];
-            $stateEncode['readerAccountLatestEndTime'] = $readerAccountStartTime;
-
-            $this->getLogger()->info(sprintf(
-                'READER_ACCOUNT_USAGE: Fetching queries completed after %s (UTC) set by last execution.',
-                $readerAccountStartTime,
-            ));
+        if ($this->getConfig()->getSkipReaderAccounts()) {
+            $this->getLogger()->info('READER_ACCOUNT_USAGE: Skipping reader account query history extraction (skipReaderAccounts is enabled).'); // phpcs:ignore
         } else {
-            $readerAccountStartTime = date('Y-m-d H:i:s', strtotime('-1 hour'));
-            $this->getLogger()->info(sprintf(
-                'READER_ACCOUNT_USAGE: Fetching queries completed in last hour - %s (UTC)',
-                $readerAccountStartTime,
-            ));
+            if (isset($stateDecoded['readerAccountLatestEndTime'])) {
+                $readerAccountStartTime = $stateDecoded['readerAccountLatestEndTime'];
+                $stateEncode['readerAccountLatestEndTime'] = $readerAccountStartTime;
+
+                $this->getLogger()->info(sprintf(
+                    'READER_ACCOUNT_USAGE: Fetching queries completed after %s (UTC) set by last execution.',
+                    $readerAccountStartTime,
+                ));
+            } else {
+                $readerAccountStartTime = date('Y-m-d H:i:s', strtotime('-1 hour'));
+                $this->getLogger()->info(sprintf(
+                    'READER_ACCOUNT_USAGE: Fetching queries completed in last hour - %s (UTC)',
+                    $readerAccountStartTime,
+                ));
+            }
+
+            try {
+                $this->readerAccountFetcher->fetchHistory(
+                    function (array $queryRow, int $rowNumber) use ($readerAccountQueries, &$stats): void {
+                        /** @var array<string, string|int> $queryRow */
+                        if ($rowNumber === 0) {
+                            // most recent query
+                            $stats['readerAccountLatestEndTime'] = $queryRow['END_TIME'];
+                        }
+
+                        if ($rowNumber > 0 && $rowNumber % 10000 === 0) {
+                            $this->getLogger()->info(sprintf(
+                                'READER_ACCOUNT_USAGE: %d queries fetched total, last processed query end time %s (UTC)', // phpcs:ignore
+                                $rowNumber,
+                                $queryRow['END_TIME'],
+                            ));
+                        }
+
+                        $stats['readerAccountRowsFetched'] = $rowNumber;
+                        $stats['readerAccountLastProcessedQueryEndTime'] = $queryRow['END_TIME'];
+                        $readerAccountQueries->writeRow($queryRow);
+                    },
+                    [
+                        'start' => $readerAccountStartTime,
+                    ],
+                );
+
+                $this->getLogger()->info(sprintf(
+                    'READER_ACCOUNT_USAGE: %d queries fetched total, last processed query end time %s (UTC)',
+                    $stats['readerAccountRowsFetched'],
+                    $stats['readerAccountLastProcessedQueryEndTime'],
+                ));
+
+                $this->getLogger()->info(sprintf(
+                    'READER_ACCOUNT_USAGE: Latest query end time is %s (UTC). Next execution will fetch queries that have completed later.', // phpcs:ignore
+                    $stats['readerAccountLatestEndTime'],
+                ));
+            } catch (RuntimeException $e) {
+                $this->getLogger()->error($e->getMessage());
+            }
+
+            $stateEncode['readerAccountLatestEndTime'] = $stats['readerAccountLatestEndTime'];
         }
 
-        try {
-            $this->readerAccountFetcher->fetchHistory(
-                function (array $queryRow, int $rowNumber) use ($readerAccountQueries, &$stats): void {
-                    /** @var array<string, string|int> $queryRow */
-                    if ($rowNumber === 0) {
-                        // most recent query
-                        $stats['readerAccountLatestEndTime'] = $queryRow['END_TIME'];
-                    }
-
-                    if ($rowNumber > 0 && $rowNumber % 10000 === 0) {
-                        $this->getLogger()->info(sprintf(
-                            'READER_ACCOUNT_USAGE: %d queries fetched total, last processed query end time %s (UTC)',
-                            $rowNumber,
-                            $queryRow['END_TIME'],
-                        ));
-                    }
-
-                    $stats['readerAccountRowsFetched'] = $rowNumber;
-                    $stats['readerAccountLastProcessedQueryEndTime'] = $queryRow['END_TIME'];
-                    $readerAccountQueries->writeRow($queryRow);
-                },
-                [
-                    'start' => $readerAccountStartTime,
-                ],
-            );
-
-            $this->getLogger()->info(sprintf(
-                'READER_ACCOUNT_USAGE: %d queries fetched total, last processed query end time %s (UTC)',
-                $stats['readerAccountRowsFetched'],
-                $stats['readerAccountLastProcessedQueryEndTime'],
-            ));
-
-            $this->getLogger()->info(sprintf(
-                'READER_ACCOUNT_USAGE: Latest query end time is %s (UTC). Next execution will fetch queries that have completed later.', // phpcs:ignore
-                $stats['readerAccountLatestEndTime'],
-            ));
-        } catch (RuntimeException $e) {
-            $this->getLogger()->error($e->getMessage());
-        }
-
-        $stateEncode['readerAccountLatestEndTime'] = $stats['readerAccountLatestEndTime'];
         $this->writeManifest($this->getDataDir() . '/out/tables/queries_reader_account.csv.manifest');
 
         (new Filesystem())->dumpFile(

--- a/src/SnowflakeQueryHistory/Config/Config.php
+++ b/src/SnowflakeQueryHistory/Config/Config.php
@@ -33,6 +33,11 @@ class Config extends BaseConfig
         return $this->getStringValue(['parameters', 'host']);
     }
 
+    public function getSkipReaderAccounts(): bool
+    {
+        return (bool) $this->getValue(['parameters', 'skipReaderAccounts'], false);
+    }
+
     private function hasPrivateKey(): bool
     {
         return !empty($this->getValue(['parameters', '#privateKey'], ''));

--- a/src/SnowflakeQueryHistory/Config/ConfigDefinition.php
+++ b/src/SnowflakeQueryHistory/Config/ConfigDefinition.php
@@ -35,6 +35,9 @@ class ConfigDefinition extends BaseConfigDefinition
             ->end()
             ->scalarNode('#privateKey')
             ->end()
+            ->booleanNode('skipReaderAccounts')
+            ->defaultFalse()
+            ->end()
             ->end();
 
         return $parametersNode;


### PR DESCRIPTION
## Summary

Adds a new boolean configuration parameter `skipReaderAccounts` (default: `false`) that, when set to `true`, skips extraction of query history from `READER_ACCOUNT_USAGE.QUERY_HISTORY`.

**Changes:**
- `ConfigDefinition.php`: Adds `booleanNode('skipReaderAccounts')` with `defaultFalse()`
- `Config.php`: Adds `getSkipReaderAccounts()` accessor
- `Component.php`: Wraps the reader account fetching block in a conditional; logs a skip message when enabled

When the flag is `false` (default), behavior is identical to before.

## Review & Testing Checklist for Human

- [ ] **State handling on toggle**: When `skipReaderAccounts` is `true`, `readerAccountLatestEndTime` in output state is set to `null`. If a user later disables the flag, reader account fetching will restart from 1 hour ago rather than resuming from where it left off. Verify this is acceptable behavior.
- [ ] **Empty output when skipping**: An empty `queries_reader_account.csv` and its manifest are still written when skipping. Confirm Keboola handles empty incremental loads gracefully.
- [ ] **End-to-end test**: Deploy a branch build via `runtime.tag`, configure `"skipReaderAccounts": true`, run the component, and verify logs show the skip message and no reader account queries are fetched. Then run with `false`/omitted and verify reader account extraction still works.

### Notes
- No test changes included — existing functional tests don't exercise this parameter.
- The existing reader account logic is unchanged; it is only wrapped in an `else` branch.

## Release Notes
**Justification, description**

New optional boolean parameter `skipReaderAccounts` allows users to disable reader account query history extraction when not needed.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk — default is `false`, preserving existing behavior. Only affects users who explicitly enable the flag.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/440dbeeb39484d9caac31268f085454b
Requested by: @pivnicek