### PR TITLE
ci: drop Snowflake password auth (DMD-873)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ grant monitor on warehouse some_warehouse to role keboola_monitoring;
 
 
 create user keboola_monitoring
-password = 'PASSWORD'
+rsa_public_key = 'MIIBIj...'
 default_role = 'KEBOOLA_MONITORING';
 
 grant role keboola_monitoring to user keboola_monitoring;
@@ -40,7 +40,7 @@ grant role keboola_monitoring to user keboola_monitoring;
     "host",
     "user",
     "database",
-    "#password",
+    "#privateKey",
     "warehouse"
   ],
   "properties": {
@@ -56,8 +56,8 @@ grant role keboola_monitoring to user keboola_monitoring;
       "minLength": 1,
       "default": ""
     },
-    "#password": {
-      "title": "Password",
+    "#privateKey": {
+      "title": "Private Key",
       "type": "string",
       "format": "password",
       "minLength": 1,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     environment:
       - SNOWFLAKE_HOST
       - SNOWFLAKE_USER
-      - SNOWFLAKE_PASSWORD
       - SNOWFLAKE_DATABASE
       - SNOWFLAKE_PRIVATEKEY
       - SNOWFLAKE_WAREHOUSE

--- a/src/SnowflakeQueryHistory/Config/Config.php
+++ b/src/SnowflakeQueryHistory/Config/Config.php
@@ -13,28 +13,17 @@ class Config extends BaseConfig
      */
     public function getConnectionConfig(): array
     {
-        $options = [
+        return [
             'host' => $this->getStringValue(['parameters', 'host']),
             'user' => $this->getStringValue(['parameters', 'user']),
-            'password' => $this->getStringValue(['parameters', '#password'], ''),
+            'privateKey' => $this->getStringValue(['parameters', '#privateKey']),
             'warehouse' => $this->getStringValue(['parameters', 'warehouse']),
             'database' => $this->getStringValue(['parameters', 'database']),
         ];
-
-        if ($this->hasPrivateKey()) {
-            $options['privateKey'] = $this->getStringValue(['parameters', '#privateKey']);
-        }
-
-        return $options;
     }
 
     public function getHost(): string
     {
         return $this->getStringValue(['parameters', 'host']);
-    }
-
-    private function hasPrivateKey(): bool
-    {
-        return !empty($this->getValue(['parameters', '#privateKey'], ''));
     }
 }

--- a/src/SnowflakeQueryHistory/Config/ConfigDefinition.php
+++ b/src/SnowflakeQueryHistory/Config/ConfigDefinition.php
@@ -31,9 +31,9 @@ class ConfigDefinition extends BaseConfigDefinition
             ->isRequired()
             ->cannotBeEmpty()
             ->end()
-            ->scalarNode('#password')
-            ->end()
             ->scalarNode('#privateKey')
+            ->isRequired()
+            ->cannotBeEmpty()
             ->end()
             ->end();
 

--- a/tests/FetcherTest.php
+++ b/tests/FetcherTest.php
@@ -17,14 +17,10 @@ class FetcherTest extends TestCase
         $options = [
             'host' => getenv('SNOWFLAKE_HOST'),
             'user' => getenv('SNOWFLAKE_USER'),
-            'password' => getenv('SNOWFLAKE_PASSWORD') ?? '',
+            'privateKey' => getenv('SNOWFLAKE_PRIVATEKEY'),
             'database' => getenv('SNOWFLAKE_DATABASE'),
             'warehouse' => getenv('SNOWFLAKE_WAREHOUSE'),
         ];
-
-        if (getenv('SNOWFLAKE_PRIVATEKEY') !== false) {
-            $options['privateKey'] = getenv('SNOWFLAKE_PRIVATEKEY');
-        }
 
         $this->connection = new Connection($options);
         $this->connection->query('alter session set timezone = \'UTC\'');

--- a/tests/functional/run-action/source/data/config.json
+++ b/tests/functional/run-action/source/data/config.json
@@ -2,7 +2,7 @@
   "parameters": {
     "host": "%env(string:SNOWFLAKE_HOST)%",
     "user": "%env(string:SNOWFLAKE_USER)%",
-    "#password": "%env(string:SNOWFLAKE_PASSWORD)%",
+    "#privateKey": "%env(string:SNOWFLAKE_PRIVATEKEY)%",
     "database": "%env(string:SNOWFLAKE_DATABASE)%",
     "warehouse": "%env(string:SNOWFLAKE_WAREHOUSE)%"
   }


### PR DESCRIPTION
## Summary

Drops Snowflake username/password auth across docker-compose, app config, tests, and docs. Key-pair auth (`SNOWFLAKE_PRIVATEKEY` / `#privateKey`) is now the only supported method. Linear: DMD-873.

## Changes

- `docker-compose.yml`: drop `SNOWFLAKE_PASSWORD` env (keep `SNOWFLAKE_PRIVATEKEY`).
- `tests/FetcherTest.php`: drop `password` option and the conditional `privateKey` branch — `privateKey` is now always wired from `SNOWFLAKE_PRIVATEKEY`.
- `src/.../Config/Config.php`: drop `password` from `getConnectionConfig()`; `privateKey` always included.
- `src/.../Config/ConfigDefinition.php`: remove `#password` node; make `#privateKey` required and non-empty.
- `README.md`: update config schema (required field, property block) and CREATE USER snippet to use `rsa_public_key` instead of `password`.

## Important — needs follow-up before merge

`.github/workflows/push.yml` still passes `SNOWFLAKE_PASSWORD` (lines 21 and 97). It does NOT pass `SNOWFLAKE_PRIVATEKEY` to the test container. Per the DMD-873 task brief I intentionally did NOT touch the workflow because the keypair counterpart isn't wired there yet.

Follow-up required (separate PR or before merge):
- add `SNOWFLAKE_PRIVATEKEY` GitHub Actions secret to the repo
- add `SNOWFLAKE_PRIVATEKEY: ${{ secrets.SNOWFLAKE_PRIVATEKEY }}` to the workflow `env:` block
- add `-e SNOWFLAKE_PRIVATEKEY \` to the `docker run` step (line ~97)
- remove the two `SNOWFLAKE_PASSWORD` references in the workflow

Until that is done CI will fail because the test container will not receive a private key.

## Test plan

- [ ] Add `SNOWFLAKE_PRIVATEKEY` secret + workflow env wiring (follow-up).
- [ ] Verify `composer ci` passes against the test account with key-pair auth only.
- [ ] Verify any existing KBC project configs are migrated to `#privateKey` (this is a breaking change for password-only configurations).
